### PR TITLE
Fix hit detection, run the system only on collision

### DIFF
--- a/src/hud.rs
+++ b/src/hud.rs
@@ -1,10 +1,4 @@
-use bevy::{
-    color::palettes::css::GOLD,
-    diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
-    prelude::*,
-};
-
-use crate::common::*;
+use bevy::prelude::*;
 
 pub fn setup(mut commands: Commands) {
     commands

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() {
                 block::update_system,
                 shooting::new_shot_system,
                 shooting::update_system,
-                shooting::collider_system,
+                shooting::collider_system.run_if(on_event::<CollisionStarted>()),
                 overlay::fps_update_system,
                 camera::update_system,
                 ui::update_system,

--- a/src/shooting.rs
+++ b/src/shooting.rs
@@ -76,9 +76,16 @@ pub fn collider_system(
     for (shot_entity, colliding_entities) in &mut collision_query {
         for entity in colliding_entities.iter() {
             if *entity != player_entity {
-                trace!("hit target");
-                commands.entity(shot_entity).despawn();
-                commands.entity(*entity).despawn();
+                let entity = *entity;
+                let shot_entity = shot_entity;
+                // this ensures the same baddy doesnt swallow two shots
+                commands.add(move |world: &mut World| {
+                    // despawn the entity and shot only if the entity actually exists
+                    if let Some(entity) = world.get_entity_mut(entity) {
+                        entity.despawn();
+                        world.despawn(shot_entity);
+                    }
+                });
             }
         }
     }


### PR DESCRIPTION
This ensures the same baddy cannot be hit by two bullets simultaneously. It also adds a "run on event" to the collider system, hopefully improving efficiency by a tiny margin.